### PR TITLE
added localStorage as a persistent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Possible values: Any combination of `top`, `left`, `right`, `bottom`.
 
 The time (in milliseconds) where it goes from red to green.
 
-#### autoload (boolean) - default: false
+#### autoload (string or boolean) - default: false
 
-Uses sessionStorage to store whether the graphic should be automatically loaded every time the page is reloaded.
+Uses the [Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Storage) to store whether the graphic should be automatically loaded every time the page is reloaded.  Pass in `'localStorage'` for persistent loading or `'sessionStorage'` to load ng-stats for only the current tab.
 
-Note, if you pass `false` as options, it will simply remove the stats window: `showAngularStats(false)`
+Note, if you pass `false` as options, it will simply remove the stats window  and exit: `showAngularStats(false)`
 
 #### trackDigest (boolean) - default: false
 

--- a/dist/ng-stats.js
+++ b/dist/ng-stats.js
@@ -52,7 +52,7 @@
   }
 
   // check for autoload
-  var autoloadOptions = sessionStorage[autoloadKey];
+  var autoloadOptions = sessionStorage[autoloadKey] || localStorage[autoloadKey];
   if (autoloadOptions) {
     autoload(JSON.parse(autoloadOptions));
   }
@@ -80,10 +80,14 @@
       current = null;
     }
 
-    // do nothing if the argument is false
-    if (opts === false) {
+    // Remove autoload if they did not specifically request it
+    if (opts === false || !opts.autoload) {
       sessionStorage.removeItem(autoloadKey);
-      return;
+      localStorage.removeItem(autoloadKey);
+      // do nothing if the argument is false
+      if (opts === false) {
+        return;
+      }
     } else {
       opts.position = opts.position || 'top-left';
       opts = angular.extend({
@@ -118,9 +122,11 @@
 
     // auto-load on startup
     if (opts.autoload) {
-      sessionStorage.setItem(autoloadKey, JSON.stringify(opts));
-    } else {
-      sessionStorage.removeItem(autoloadKey);
+      if (opts.autoload === 'localStorage') {
+        localStorage.setItem(autoloadKey, JSON.stringify(opts));
+      } else {
+        sessionStorage.setItem(autoloadKey, JSON.stringify(opts));
+      }
     }
 
     // general variables


### PR DESCRIPTION
This is also backwards-compatible, as it defaults to `sessionStorage` when `opts.autoload` is truthy but not `"localStorage"`