### PR TITLE
false should be a valid value for opts

### DIFF
--- a/dist/ng-stats.js
+++ b/dist/ng-stats.js
@@ -69,7 +69,7 @@
   }
 
   function showAngularStats(opts) {
-    opts = opts || {};
+    opts = opts !== undefined ? opts : {};
     var returnData = {
       listeners: listeners
     };


### PR DESCRIPTION
If `opts` is false (for instance, in the case where we want to clear Storage and exit), then it will be set to an empty object and cause a jQuery bug.  Instead, strictly check against `undefined`