### PR TITLE
Enables an option to set an HTML ID attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ based on the digestTimeThreshold.
 
 Setting this to true will cause ng-stats to log out the watch count to the console as it changes.
 
+#### htmlId (string) - default: null
+
+Sets an HTML ID attribute to the rendered stats element.
+
 ## Module
 
 Simply declare it as a dependency `angular.module('your-mod', ['angularStats']);`

--- a/dist/ng-stats.js
+++ b/dist/ng-stats.js
@@ -92,7 +92,6 @@
 
     opts.position = opts.position || 'top-left';
     opts = angular.extend({
-      htmlId: null,
       digestTimeThreshold: 16,
       autoload: false,
       trackDigest: false,
@@ -137,8 +136,7 @@
     var noDigestSteps = 0;
 
     // add the DOM element
-    var htmlId = opts.statsId ? (' id="' + opts.htmlId + '"') : '';
-    state.$el = angular.element('<div' + htmlId + '><canvas></canvas><div></div></div>').css(opts.styles);
+    state.$el = angular.element('<div><canvas></canvas><div></div></div>').css(opts.styles);
     bodyEl.append(state.$el);
     var $text = state.$el.find('div');
 

--- a/dist/ng-stats.js
+++ b/dist/ng-stats.js
@@ -92,6 +92,7 @@
 
     opts.position = opts.position || 'top-left';
     opts = angular.extend({
+      htmlId: null,
       digestTimeThreshold: 16,
       autoload: false,
       trackDigest: false,
@@ -136,7 +137,8 @@
     var noDigestSteps = 0;
 
     // add the DOM element
-    state.$el = angular.element('<div><canvas></canvas><div></div></div>').css(opts.styles);
+    var htmlId = opts.statsId ? (' id="' + opts.htmlId + '"') : '';
+    state.$el = angular.element('<div' + htmlId + '><canvas></canvas><div></div></div>').css(opts.styles);
     bodyEl.append(state.$el);
     var $text = state.$el.find('div');
 

--- a/src/ng-stats.js
+++ b/src/ng-stats.js
@@ -99,6 +99,7 @@
 
     opts.position = opts.position || 'top-left';
     opts = angular.extend({
+      htmlId: null,
       digestTimeThreshold: 16,
       autoload: false,
       trackDigest: false,
@@ -143,7 +144,8 @@
     var noDigestSteps = 0;
 
     // add the DOM element
-    state.$el = angular.element('<div><canvas></canvas><div></div></div>').css(opts.styles);
+    var htmlId = opts.htmlId ? (' id="' + opts.htmlId + '"') : '';
+    state.$el = angular.element('<div' + htmlId + '><canvas></canvas><div></div></div>').css(opts.styles);
     bodyEl.append(state.$el);
     var $text = state.$el.find('div');
 


### PR DESCRIPTION
It's useful to set an ID attribute to the charts. This helps in dynamically styling or even hiding certain parts of the charts using CSS.