### PR TITLE
Ionic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ Setting this to true will cause ng-stats to log out the watch count to the conso
 
 Sets an HTML ID attribute to the rendered stats element.
 
+#### rootScope (object) - default: undefined
+
+Passes the $rootScope to ng-stats. This parameter is only required for Ionic support where the ng-scope and ng-isolate-scope classes are removed. The only way of using the ng-stats with Ionic is invoking `showAngularStats( { options } )` in your code and passing the `$rootScope` manually.
+
 ## Module
 
 Simply declare it as a dependency `angular.module('your-mod', ['angularStats']);`

--- a/src/index.js
+++ b/src/index.js
@@ -73,21 +73,7 @@ function autoload(options) {
   }
 }
 
-function showAngularStats(opts) {
-  /* eslint max-statements:[2, 45] */
-  /* eslint complexity:[2, 18] */
-  /* eslint consistent-return:0 */
-  // TODO ^^ fix these things...
-  opts = opts !== undefined ? opts : {};
-  var returnData = {
-    listeners: listeners
-  };
-  // delete the previous one
-  if (current) {
-    current.$el && current.$el.remove();
-    current.active = false;
-    current = null;
-  }
+function initOptions(opts) {
 
   // Remove autoload if they did not specifically request it
   if (opts === false || !opts.autoload) {
@@ -102,6 +88,7 @@ function showAngularStats(opts) {
   opts.position = opts.position || 'top-left';
   opts = angular.extend({
     htmlId: null,
+    rootScope: undefined,
     digestTimeThreshold: 16,
     watchCountThreshold: 2000,
     autoload: false,
@@ -125,6 +112,33 @@ function showAngularStats(opts) {
       left: opts.position.indexOf('left') === -1 ? null : 0
     }
   }, opts || {});
+
+  // for ionic support
+  if (opts.rootScope) {
+    $rootScope = opts.rootScope;
+  }
+
+  return opts;
+}
+
+function showAngularStats(opts) {
+  /* eslint max-statements:[2, 45] */
+  /* eslint complexity:[2, 18] */
+  /* eslint consistent-return:0 */
+  // TODO ^^ fix these things...
+  opts = opts !== undefined ? opts : {};
+  var returnData = {
+    listeners: listeners
+  };
+  // delete the previous one
+  if (current) {
+    current.$el && current.$el.remove();
+    current.active = false;
+    current = null;
+  }
+
+  // Implemented in separate function due to webpack's statement count limit
+  opts = initOptions(opts);
 
   hijackDigest();
 


### PR DESCRIPTION
Hi @kentcdodds ,

love the tool, but I was trying to use the tool with Ionic but I was keep receiving "ReferenceError: $rootScope is not defined" error since ng-scope and ng-isolate-scope classes are removed by Ionic. Was already discussed in Issue #3.

My fix works only when using the tool from the code calling the showAngularStats function. At least the rootScope parameter has to be defined like this: showAngularStats({"rootScope": $rootScope});

When building, I was receiving "This function has too many statements" error from webpack. I also fixed that by moving the option pre-setup into separate function.